### PR TITLE
 Fix/GAMES-7328-audio-cache-invalidation

### DIFF
--- a/.changeset/audio-cache-invalidation.md
+++ b/.changeset/audio-cache-invalidation.md
@@ -1,0 +1,5 @@
+---
+"@releaseband/vite-plugin-meta": patch
+---
+
+Invalidate audio conversion cache when audio optimization options change.

--- a/src/MetaPlugin.ts
+++ b/src/MetaPlugin.ts
@@ -176,7 +176,7 @@ export default class MetaPlugin {
 	private async soundsConversionProcess(): Promise<void> {
 		const jobs = this.soundsFiles.map(async (soundPath) => {
 			try {
-				const fileHash = await makeHash(soundPath);
+				const fileHash = `${await makeHash(soundPath)}:${JSON.stringify(this.formats)}`;
 				if (this.option.convertLog) console.log(soundPath, this.filesHash[soundPath], fileHash);
 				if (this.filesHash[soundPath] === fileHash) return;
 				if (this.option.fileChangeLog) fileLog(`file conversion "${soundPath}" started`);


### PR DESCRIPTION
в vite-plugin-meta кеш аудио считался только по md5 исходного wav. Настройки audioOptimization в хеш не входили,  поэтому при смене sampleRate/channels/quality/bitrate плагин  брал старые .mp3/.ogg/.m4a из кеша и копировать их в build